### PR TITLE
photon-xavier-nx: build c-boot from source

### DIFF
--- a/layers/meta-hawkeye-jetson/conf/machine/photon-xavier-nx.conf
+++ b/layers/meta-hawkeye-jetson/conf/machine/photon-xavier-nx.conf
@@ -8,6 +8,3 @@ include conf/machine/jetson-xavier-nx-devkit-emmc.conf
 
 PACKAGE_EXTRA_ARCHS_append = " jetson-xavier-nx-devkit-emmc"
 KERNEL_DEVICETREE = "_ddot_/_ddot_/_ddot_/_ddot_/nvidia/platform/t19x/jakku/kernel-dts/tegra194-xavier-nx-cti-NGX003.dtb"
-
-# XXX Building t19x c-boot from source is currently broken
-PREFERRED_PROVIDER_virtual/bootloader = "cboot-prebuilt"


### PR DESCRIPTION
Remove the override that makes xavier-nx use prebuilt c-boot. Building from source works fine with r32.5.