### PR TITLE
Add AAEON BOXER 8221, 8251 machines

### DIFF
--- a/layers/meta-hawkeye-jetson/conf/machine/boxer-8221-emmc.conf
+++ b/layers/meta-hawkeye-jetson/conf/machine/boxer-8221-emmc.conf
@@ -1,0 +1,9 @@
+#@TYPE: Machine
+##@NAME: boxer-8221-emmc
+##@DESCRIPTION: Machine configuration for the AAEON BOXER-8221AI eMMC
+
+require conf/machine/jetson-nano-devkit-emmc.conf
+
+# Remove $MACHINE which is prepended by including jetson-nano-devkit-emmc
+# and fix the order of overrides
+MACHINEOVERRIDES := "${@'${MACHINEOVERRIDES}'.replace(':${MACHINE}',':jetson-nano-emmc:boxer-nano:${MACHINE}')}"

--- a/layers/meta-hawkeye-jetson/conf/machine/boxer-8251.conf
+++ b/layers/meta-hawkeye-jetson/conf/machine/boxer-8251.conf
@@ -1,0 +1,9 @@
+#@TYPE: Machine
+##@NAME: boxer-8251
+##@DESCRIPTION: Machine configuration for the AAEON BOXER-8251AI
+
+include conf/machine/jetson-xavier-nx-devkit-emmc.conf
+
+# Remove $MACHINE which is prepended by including jetson-xavier-nx-devkit
+# and fix the order of overrides
+MACHINEOVERRIDES := "${@'${MACHINEOVERRIDES}'.replace(':${MACHINE}',':jetson-xavier-nx-devkit-emmc:boxer-nx:${MACHINE}')}"

--- a/layers/meta-hawkeye-jetson/recipes-kernel/linux/linux-tegra/0001-nvidia-t210-enable-sdmmc3.patch
+++ b/layers/meta-hawkeye-jetson/recipes-kernel/linux/linux-tegra/0001-nvidia-t210-enable-sdmmc3.patch
@@ -1,0 +1,27 @@
+From e2565fa793cd5108e048d246343e65738e87a69e Mon Sep 17 00:00:00 2001
+From: Pelle van Gils <pelle@hwky.ai>
+Date: Thu, 16 Sep 2021 15:54:48 +0200
+Subject: [PATCH 1/2] nvidia/t210: enable sdmmc3
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Pelle van Gils <pelle@hwky.ai>
+---
+ .../t210/porg/kernel-dts/tegra210-porg-p3448-common.dtsi        | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/nvidia/platform/t210/porg/kernel-dts/tegra210-porg-p3448-common.dtsi b/nvidia/platform/t210/porg/kernel-dts/tegra210-porg-p3448-common.dtsi
+index 2a7d84445089..25a7d7b42563 100644
+--- a/nvidia/platform/t210/porg/kernel-dts/tegra210-porg-p3448-common.dtsi
++++ b/nvidia/platform/t210/porg/kernel-dts/tegra210-porg-p3448-common.dtsi
+@@ -283,7 +283,7 @@
+ 	};
+ 
+ 	sdhci@700b0400 {
+-		status = "disabled";
++		status = "enabled";
+ 		/delete-property/ keep-power-in-suspend;
+ 		/delete-property/ non-removable;
+ 		mmc-ddr-1_8v;
+-- 
+2.33.0
+

--- a/layers/meta-hawkeye-jetson/recipes-kernel/linux/linux-tegra/0002-nvidia-t194-enable-sdmmc3.patch
+++ b/layers/meta-hawkeye-jetson/recipes-kernel/linux/linux-tegra/0002-nvidia-t194-enable-sdmmc3.patch
@@ -1,0 +1,34 @@
+From c1a106b17fe72b853927c8be67b817405b52ea67 Mon Sep 17 00:00:00 2001
+From: Pelle van Gils <pelle@hwky.ai>
+Date: Thu, 16 Sep 2021 16:01:49 +0200
+Subject: [PATCH 2/2] nvidia/t194: enable sdmmc3
+
+The patch was imported from https://gist.github.com/KunYi/4bfed30195bf2919f23b143da3eee339
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Pelle van Gils <pelle@hwky.ai>
+---
+ .../jakku/kernel-dts/tegra194-p3668-all-p3509-0000.dts | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-all-p3509-0000.dts b/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-all-p3509-0000.dts
+index b724f6279071..2e6b85b09633 100644
+--- a/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-all-p3509-0000.dts
++++ b/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-all-p3509-0000.dts
+@@ -23,3 +23,13 @@
+ 
+ 	compatible = "nvidia,p3449-0000+p3668-0000", "nvidia,p3449-0000+p3668-0001", "nvidia,p3509-0000+p3668-0000", "nvidia,p3509-0000+p3668-0001", "nvidia,tegra194";
+ };
++
++&sdmmc3 {
++    mmc-ocr-mask = <0x0>;
++    cd-gpios = <&tegra_main_gpio TEGRA194_MAIN_GPIO(Q, 2) 0>;
++    cd-inverted;
++    nvidia,cd-wakeup-capable;
++    nvidia,vmmc-always-on;
++    vmmc-supply = <&p3668_spmic_ldo3>;
++    status = "okay";
++};
+-- 
+2.33.0
+

--- a/layers/meta-hawkeye-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
+++ b/layers/meta-hawkeye-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
@@ -15,6 +15,14 @@ SRC_URI_append_photon-nano = " \
     file://0001-dts-t210-enable-SMMU-to-fix-QCA-pcie-wifi.patch \
 "
 
+SRC_URI_append_boxer-nano = " \
+    file://0001-nvidia-t210-enable-sdmmc3.patch \
+"
+
+SRC_URI_append_boxer-nx = " \
+    file://0002-nvidia-t194-enable-sdmmc3.patch \
+"
+
 SRCBRANCH = "tegra-l4t-r${L4T_VERSION}"
 SRCREV = "76e8cd5c8175ec147258315b56bdf1830bc663de"
 


### PR DESCRIPTION
This adds initial support for the AAEON BOXER 8221AI (Jetson nano emmc) and BOXER 8251AI (Jetson Xavier NX) devices.

These are basically devkits with SD-card readers. This PR includes patches supplied by AAEON to enable the card readers.

https://www.aaeon.com/en/c/aaeon-nvidia-ai-solutions